### PR TITLE
Add sortable admin tables to development

### DIFF
--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -371,7 +371,6 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	Array				Modified array of sortable table columns
 	 */
 	public function setSortableItemsTableColumns(Array $columns) {
-		// Makes array of columns sortable
 		foreach(['taxonomy-wp_lib_media_type','taxonomy-wp_lib_author','item_status','item_condition'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
@@ -385,7 +384,6 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	Array				Modified array of sortable table columns
 	 */
 	public function setSortableMembersTableColumns(Array $columns) {
-		// Makes array of columns sortable
 		foreach(['member_name','member_loans','member_fines','member_donated'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
@@ -399,7 +397,6 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	Array				Modified array of sortable table columns
 	 */
 	public function setSortableLoansTableColumns(Array $columns) {
-		// Makes array of columns sortable
 		foreach(['loan_loan','loan_item','loan_member','loan_status','loan_start','loan_end','loan_returned'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
@@ -413,7 +410,6 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	Array				Modified array of sortable table columns
 	 */
 	public function setSortableFinesTableColumns(Array $columns) {
-		// Makes array of columns sortable
 		foreach(['fine_fine','fine_item','fine_member','fine_status','fine_amount'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -434,6 +434,15 @@ class WP_LIB_ADMIN_TABLES {
 	}
 	
 	/**
+	 * Sets whether sorting will be ascending or descending based on input
+	 * @param	WP_Query	$wp_query	Query for a library post type
+	 * @return	string					ASC/DESC prefixed with a single space
+	 */
+	private function getColumnSortDirection(WP_Query $wp_query) {
+		return ' ' . (('ASC' == strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC');
+	}
+	
+	/**
 	 * Defines custom logic for sorting the Items table's custom taxonomy columns
 	 * Adapted from Mike Schinkel's comment on Scribu's post: 
 	 * @link	http://scribu.net/wordpress/sortable-taxonomy-columns.html#direct-joins
@@ -469,8 +478,8 @@ SQL;
 		
 		$clauses['where']	.=	" AND (taxonomy = '".$taxonomy."' OR taxonomy IS NULL)";
 		$clauses['groupby']	=	"object_id";
-		$clauses['orderby']	=	"GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC) ";
-		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
+		$clauses['orderby']	=	"GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC)";
+		$clauses['orderby']	.=	$this->getColumnSortDirection($wp_query);
 
 		return $clauses;
 	}
@@ -520,8 +529,8 @@ LEFT OUTER JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID={$wpdb->postmeta}.post_id
 LEFT OUTER JOIN {$wpdb->posts} AS wp_lib_cpt ON meta_value=wp_lib_cpt.ID
 SQL;
 		
-		$clauses['orderby']	=	"wp_lib_cpt.post_title ";
-		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
+		$clauses['orderby']	=	"wp_lib_cpt.post_title";
+		$clauses['orderby']	.=	$this->getColumnSortDirection($wp_query);
 		
 		return $clauses;
 	}
@@ -540,8 +549,8 @@ SQL;
 		
 		$clauses['join']	.=	"LEFT OUTER JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID={$wpdb->postmeta}.meta_value AND {$wpdb->postmeta}.meta_key='wp_lib_item_donor'";
 		$clauses['groupby']	=	"ID";
-		$clauses['orderby']	=	"COUNT(meta_value) ";
-		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
+		$clauses['orderby']	=	"COUNT(meta_value)";
+		$clauses['orderby']	.=	$this->getColumnSortDirection($wp_query);
 		
 		return $clauses;
 	}
@@ -578,8 +587,8 @@ ON {$wpdb->posts}.ID = loans.member_id
 SQL;
 		
 		$clauses['groupby']	=	"{$wpdb->posts}.ID";
-		$clauses['orderby'] =	"COUNT(loans.member_id) ";
-		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
+		$clauses['orderby'] =	"COUNT(loans.member_id)";
+		$clauses['orderby']	.=	$this->getColumnSortDirection($wp_query);
 		
 		return $clauses;
 	}
@@ -606,8 +615,8 @@ ON {$wpdb->posts}.ID=start_meta.post_id
 AND start_meta.meta_key='wp_lib_start_date'
 SQL;
 		
-		$clauses['orderby'] =	"IFNULL(give_meta.meta_value, start_meta.meta_value) ";
-		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
+		$clauses['orderby'] =	"IFNULL(give_meta.meta_value, start_meta.meta_value)";
+		$clauses['orderby']	.=	$this->getColumnSortDirection($wp_query);
 		
 		return $clauses;
 	}

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -443,11 +443,11 @@ class WP_LIB_ADMIN_TABLES {
 	}
 	
 	/**
-	 * Defines custom logic for sorting the Items table's custom taxonomy columns
+	 * Defines custom logic for sorting the Items table by its custom taxonomy columns
 	 * Adapted from Mike Schinkel's comment on Scribu's post: 
 	 * @link	http://scribu.net/wordpress/sortable-taxonomy-columns.html#direct-joins
 	 * @param	Array		$clauses	SQL clauses for fetching posts
-	 * @param	WP_Query	$wp_query	A request to WordPress for posts
+	 * @param	WP_Query	$wp_query	A paginated query for items
 	 * @return	Array					Modified SQL clauses
 	 */
 	public function sortByTaxColumn(Array $clauses, WP_Query $wp_query) {
@@ -486,9 +486,8 @@ SQL;
 	
 	/**
 	 * Sorts a custom column by its value, where that value comes a different post type's title
-	 * @todo							Give this function a better name
 	 * @param	Array		$clauses	SQL clauses for fetching posts
-	 * @param	WP_Query	$wp_query	A request to WordPress for posts
+	 * @param	WP_Query	$wp_query	A paginated query for a library post type
 	 * @return	Array					Modified SQL clauses
 	 */
 	public function sortByForeignMetaColumn(Array $clauses, WP_Query $wp_query) {
@@ -536,9 +535,9 @@ SQL;
 	}
 	
 	/**
-	 * Sorts the 'Items Donated' column in the Members table
+	 * Sorts the members table by its 'Items Donated' column
 	 * @param	Array		$clauses	SQL clauses for fetching posts
-	 * @param	WP_Query	$wp_query	A request to WordPress for posts
+	 * @param	WP_Query	$wp_query	A paginated query for members
 	 * @return	Array					Modified SQL clauses
 	 */
 	public function sortByItemsDonatedColumn(Array $clauses, WP_Query $wp_query) {
@@ -560,7 +559,7 @@ SQL;
 	 * First creates a table of items currently on loan then joins them to the relevant members and counts how many items each member has
 	 * @todo Find out if this can be done without a nested query
 	 * @param	Array		$clauses	SQL clauses for fetching posts
-	 * @param	WP_Query	$wp_query	A request to WordPress for posts
+	 * @param	WP_Query	$wp_query	A paginated query for members
 	 * @return	Array					Modified SQL clauses
 	 */
 	public function sortByItemsOnLoanColumn(Array $clauses, WP_Query $wp_query) {
@@ -597,7 +596,7 @@ SQL;
 	 * Sorts the 'Start Date' column in the Loans table
 	 * Combines start date/give date of loan, choosing give date over start date, then sorts
 	 * @param	Array		$clauses	SQL clauses for fetching posts
-	 * @param	WP_Query	$wp_query	A request to WordPress for posts
+	 * @param	WP_Query	$wp_query	A paginated query for loans
 	 * @return	Array					Modified SQL clauses
 	 */
 	public function sortByStartDateColumn(Array $clauses, WP_Query $wp_query) {
@@ -623,7 +622,7 @@ SQL;
 	
 	/**
 	 * Tells WordPress how to sort the Items table's custom post meta columns
-	 * @param	Array		$vars		Query variables passed to default main SQL query
+	 * @param	Array	$vars	A paginated query for a library custom post type
 	 */
 	public function sortByMetaColumn(WP_Query $query) {
 		if(!is_admin())

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -624,42 +624,42 @@ SQL;
 	 * Tells WordPress how to sort the Items table's custom post meta columns
 	 * @param	Array	$vars	A paginated query for a library custom post type
 	 */
-	public function sortByMetaColumn(WP_Query $query) {
+	public function sortByMetaColumn(WP_Query $wp_query) {
 		if(!is_admin())
 			return;
 		
 		// Adds sorting logic based on column being sorted
-		switch($query->get( 'orderby')) {
+		switch($wp_query->get( 'orderby')) {
 			case 'item_status':
 				// Requires special logic
 			break;
 			
 			case 'item_condition':
-				$query->set('meta_key',	'wp_lib_item_condition');
-				$query->set('orderby',	'meta_value_num');
+				$wp_query->set('meta_key',	'wp_lib_item_condition');
+				$wp_query->set('orderby',	'meta_value_num');
 			break;
 			
 			case 'member_name':
-				$query->set('orderby',	'title');	// Member's names are stored as the title of their post
+				$wp_query->set('orderby',	'title');	// Member's names are stored as the title of their post
 			break;
 			
 			case 'loan_loan':
-				$query->set('orderby',	'ID');
+				$wp_query->set('orderby',	'ID');
 			break;
 			
 			case 'loan_status':
-				$query->set('meta_key',	'wp_lib_status');
-				$query->set('orderby',	'meta_value_num');
+				$wp_query->set('meta_key',	'wp_lib_status');
+				$wp_query->set('orderby',	'meta_value_num');
 			break;
 			
 			case 'loan_end':
-				$query->set('meta_key',	'wp_lib_end_date');
-				$query->set('orderby',	'meta_value_num');
-				$query->set('meta_type','NUMERIC');
+				$wp_query->set('meta_key',	'wp_lib_end_date');
+				$wp_query->set('orderby',	'meta_value_num');
+				$wp_query->set('meta_type','NUMERIC');
 			break;
 			
 			case 'loan_returned':
-				$query->set('meta_query',array(
+				$wp_query->set('meta_query',array(
 					'relation'	=> 'OR',
 					array(
 						'key'		=> 'wp_lib_return_date',
@@ -671,22 +671,22 @@ SQL;
 						'value'		=> 'bug #23268'	// Allows WP-Librarian to run on pre-3.9 WP installs (bug was fixed for 3.9, text is arbitrary)
 					)
 				));
-				$query->set('orderby',	'meta_value_num');
-				$query->set('meta_type','NUMERIC');
+				$wp_query->set('orderby',	'meta_value_num');
+				$wp_query->set('meta_type','NUMERIC');
 			break;
 			
 			case 'fine_fine':
-				$query->set('orderby',	'ID');
+				$wp_query->set('orderby',	'ID');
 			break;
 			
 			case 'fine_status':
-				$query->set('meta_key',	'wp_lib_status');
-				$query->set('orderby',	'meta_value_num');
+				$wp_query->set('meta_key',	'wp_lib_status');
+				$wp_query->set('orderby',	'meta_value_num');
 			break;
 			
 			case 'fine_amount':
-				$query->set('meta_key',	'wp_lib_owed');
-				$query->set('orderby',	'meta_value_num');
+				$wp_query->set('meta_key',	'wp_lib_owed');
+				$wp_query->set('orderby',	'meta_value_num');
 			break;
 		}
 	}

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -660,7 +660,18 @@ SQL;
 			break;
 			
 			case 'loan_returned':
-				$query->set('meta_key',	'wp_lib_return_date');
+				$query->set('meta_query',array(
+					'relation'	=> 'OR',
+					array(
+						'key'		=> 'wp_lib_return_date',
+						'compare'	=> 'EXISTS'
+					),
+					array(
+						'key'		=> 'wp_lib_return_date',
+						'compare'	=> 'NOT EXISTS',
+						'value'		=> 'bug #23268'	// Allows WP-Librarian to run on pre-3.9 WP installs (bug was fixed for 3.9, text is arbitrary)
+					)
+				));
 				$query->set('orderby',	'meta_value_num');
 				$query->set('meta_type','NUMERIC');
 			break;

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -573,7 +573,7 @@ SQL;
 	 * @param	Array		$vars		Query variables passed to default main SQL query
 	 */
 	public function sortCustomMetaColumns(WP_Query $query) {
-		if(!is_admin())  
+		if(!is_admin())
 			return;
 		
 		// Adds sorting logic based on column being sorted

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -27,20 +27,20 @@ class WP_LIB_ADMIN_TABLES {
 		$this->wp_librarian = $wp_librarian;
 		
 		// Adds custom columns, removes unneeded columns and changes the order of columns
-		add_filter( 'manage_wp_lib_items_posts_columns',		array( $this, 'manageItemsTableColumns' ),	10, 1 );
-		add_filter( 'manage_wp_lib_members_posts_columns',		array( $this, 'manageMembersTableColumns' ),10, 1 );
-		add_filter( 'manage_wp_lib_loans_posts_columns',		array( $this, 'manageLoansTableColumns' ),	10, 1 );
-		add_filter( 'manage_wp_lib_fines_posts_columns',		array( $this, 'manageFinesTableColumns' ),	10, 1 );
-		add_filter( 'manage_users_columns',						array( $this, 'manageUsersTableColumns' ),	10, 1 );
+		add_filter( 'manage_wp_lib_items_posts_columns',		array( $this,			'manageItemsTableColumns' ),	10, 1 );
+		add_filter( 'manage_wp_lib_members_posts_columns',		array( $this,			'manageMembersTableColumns' ),	10, 1 );
+		add_filter( 'manage_wp_lib_loans_posts_columns',		array( $this,			'manageLoansTableColumns' ),	10, 1 );
+		add_filter( 'manage_wp_lib_fines_posts_columns',		array( $this,			'manageFinesTableColumns' ),	10, 1 );
+		add_filter( 'manage_users_columns',						array( $this,			'manageUsersTableColumns' ),	10, 1 );
 		
-		add_action( 'load-edit.php',							array( $wp_librarian, 'loadObjectClasses' ) );
+		add_action( 'load-edit.php',							array( $wp_librarian,	'loadObjectClasses' ) );
 		
 		// Adds content to custom post table columns
-		add_action( 'manage_wp_lib_items_posts_custom_column',	array( $this, 'fillItemsTableColumns' ),	10, 2 );
-		add_action( 'manage_wp_lib_members_posts_custom_column',array( $this, 'fillMembersTableColumns' ),	10, 2 );
-		add_action( 'manage_wp_lib_loans_posts_custom_column',	array( $this, 'fillLoansTableColumns' ),	10, 2 );
-		add_action( 'manage_wp_lib_fines_posts_custom_column',	array( $this, 'fillFinesTableColumns' ),	10, 2 );
-		add_action( 'manage_users_custom_column',				array( $this, 'fillUsersTableColumns' ),	10, 3 );
+		add_action( 'manage_wp_lib_items_posts_custom_column',	array( $this,			'fillItemsTableColumns' ),		10, 2 );
+		add_action( 'manage_wp_lib_members_posts_custom_column',array( $this,			'fillMembersTableColumns' ),	10, 2 );
+		add_action( 'manage_wp_lib_loans_posts_custom_column',	array( $this,			'fillLoansTableColumns' ),		10, 2 );
+		add_action( 'manage_wp_lib_fines_posts_custom_column',	array( $this,			'fillFinesTableColumns' ),		10, 2 );
+		add_action( 'manage_users_custom_column',				array( $this,			'fillUsersTableColumns' ),		10, 3 );
 		
 		// Removes bulk actions actions from loans and fines post tables
 		add_filter('bulk_actions-edit-wp_lib_loans',			function(){ return array(); });

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -49,22 +49,22 @@ class WP_LIB_ADMIN_TABLES {
 		add_filter('manage_edit-wp_lib_fines_sortable_columns',		array($this,			'setSortableFinesTableColumns'),	10, 1);
 		
 		// Adds custom sorting logic to custom taxonomy columns
-		add_filter('posts_clauses',									array($this,			'sortCustomTaxColumns'),			10, 2);
+		add_filter('posts_clauses',									array($this,			'sortByTaxColumn'),					10, 2);
 		
 		// Adds custom sorting logic to columns that rely on meta-based foreign keys
-		add_filter('posts_clauses',									array($this,			'sortCustomForeignMetaColumns'),	10, 2);
+		add_filter('posts_clauses',									array($this,			'sortByForeignMetaColumn'),			10, 2);
 		
 		// Adds logic to sort the members table by the 'Items Donated' column
-		add_filter('posts_clauses',									array($this,			'sortCustomItemsDonatedColumn'),	10, 2);
+		add_filter('posts_clauses',									array($this,			'sortByItemsDonatedColumn'),		10, 2);
 		
 		// Adds logic to sort the members table by the 'Items on Loan' column
-		add_filter('posts_clauses',									array($this,			'sortCustomItemsOnLoanColumn'),		10, 2);
+		add_filter('posts_clauses',									array($this,			'sortByItemsOnLoanColumn'),			10, 2);
 		
 		// Adds logic to sort the loans table by the 'Start Date' column
-		add_filter('posts_clauses',									array($this,			'sortCustomStartDateColumn'),		10, 2);
+		add_filter('posts_clauses',									array($this,			'sortByStartDateColumn'),			10, 2);
 		
 		// Adds custom sorting logic to custom post meta columns
-		add_action('pre_get_posts',									array($this,			'sortCustomMetaColumns'),			10, 1);
+		add_action('pre_get_posts',									array($this,			'sortByMetaColumn'),				10, 1);
 		
 		// Removes bulk actions actions from loans and fines post tables
 		add_filter('bulk_actions-edit-wp_lib_loans',				function(){ return array(); });
@@ -450,7 +450,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomTaxColumns(Array $clauses, WP_Query $wp_query) {
+	public function sortByTaxColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']))
 			return $clauses;
 		
@@ -491,7 +491,7 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomForeignMetaColumns(Array $clauses, WP_Query $wp_query) {
+	public function sortByForeignMetaColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']))
 			return $clauses;
 		
@@ -541,7 +541,7 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomItemsDonatedColumn(Array $clauses, WP_Query $wp_query) {
+	public function sortByItemsDonatedColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']) || $wp_query->query['orderby'] !== 'member_donated')
 			return $clauses;
 		
@@ -563,7 +563,7 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomItemsOnLoanColumn(Array $clauses, WP_Query $wp_query) {
+	public function sortByItemsOnLoanColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']) || $wp_query->query['orderby'] !== 'member_loans')
 			return $clauses;
 		
@@ -600,7 +600,7 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomStartDateColumn(Array $clauses, WP_Query $wp_query) {
+	public function sortByStartDateColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']) || $wp_query->query['orderby'] !== 'loan_start')
 			return $clauses;
 		
@@ -625,7 +625,7 @@ SQL;
 	 * Tells WordPress how to sort the Items table's custom post meta columns
 	 * @param	Array		$vars		Query variables passed to default main SQL query
 	 */
-	public function sortCustomMetaColumns(WP_Query $query) {
+	public function sortByMetaColumn(WP_Query $query) {
 		if(!is_admin())
 			return;
 		

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -91,7 +91,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	array				Modified WordPress post table columns
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 */
-	public function manageItemsTableColumns($columns) {	
+	public function manageItemsTableColumns(Array $columns) {	
 		// Adds item status and item condition columns
 		$new_columns = array(
 			'item_status'		=> 'Loan Status',
@@ -110,7 +110,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	array				Modified WordPress post table columns
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 */
-	public function manageMembersTableColumns($columns) {
+	public function manageMembersTableColumns(Array $columns) {
 		// Initialises new columns
 		$new_columns = array(
 			'member_name'		=> 'Name',
@@ -130,7 +130,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 * @todo						Test function without accepting $columns as an argument and setting the filter params to 0
 	 */
-	public function manageLoansTableColumns($columns) {
+	public function manageLoansTableColumns(Array $columns) {
 		return array(
 			'loan_loan'			=> 'Loan',
 			'loan_item'			=> 'Item',
@@ -149,7 +149,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 * @todo						Test function without accepting $columns as an argument and setting the filter params to 0
 	 */
-	public function manageFinesTableColumns($columns) {
+	public function manageFinesTableColumns(Array $columns) {
 		return array(
 			'fine_fine'			=> 'Fine',
 			'fine_item'			=> 'Item',
@@ -165,7 +165,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	array				Modified WordPress user table columns
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_users_columns
 	 */
-	public function manageUsersTableColumns($columns) {
+	public function manageUsersTableColumns(Array $columns) {
 		return array_slice($columns, 0, 5, true) + array('library-role' => 'Library Role') + array_slice($columns, 5, NULL, true);
 	}
 	

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -384,7 +384,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	Array				Modified array of sortable table columns
 	 */
 	public function setSortableMembersTableColumns(Array $columns) {
-		foreach(['member_name','member_loans','member_fines','member_donated'] as $sortable) {
+		foreach(['member_name','member_loans','member_donated'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
 		
@@ -589,10 +589,6 @@ SQL;
 			
 			case 'member_name':
 				$query->set('orderby',	'title');	// Member's names are stored as the title of their post
-			break;
-			
-			case 'member_fines':
-				// Requires special logic
 			break;
 			
 			case 'loan_loan':

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -70,12 +70,25 @@ class WP_LIB_ADMIN_TABLES {
 	
 	/**
 	 * Fetches UNIX timestamp from post meta and, if timestamp exists, formats
-	 * @param	int		$item_id		Post ID to get post meta from
-	 * @param	string	$meta_key		Post meta key where timestamp is located
+	 * @param	int				$item_id		Post ID to get post meta from
+	 * @param	string|array	$meta_key		Post meta key(s) where timestamp is located
 	 */
 	private function dateColumn($post_id, $meta_key) {
-		// Fetches date from post meta using given key
-		$date = get_post_meta($post_id, $meta_key, true);
+		// If there are multiple dates to choose from, chooses last given date that exists
+		if (is_array($meta_key)) {
+			$values = [];
+			
+			foreach ($meta_key as $key) {
+				$values[] = get_post_meta($post_id, $key, true);
+			}
+			
+			$values = array_filter($values);
+			
+			$date = end($values);
+		} else {
+			// Fetches date from post meta using given key
+			$date = get_post_meta($post_id, $meta_key, true);
+		}
 		
 		// If date is valid returns formatted date
 		if (is_numeric($date))
@@ -294,7 +307,7 @@ class WP_LIB_ADMIN_TABLES {
 			
 			// Displays date item was loaned
 			case 'loan_start':
-				$this->dateColumn($loan_id, 'wp_lib_start_date');
+				$this->dateColumn($loan_id, array('wp_lib_start_date', 'wp_lib_give_date'));
 			break;
 			
 			// Displays date item should be returned by

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -27,20 +27,26 @@ class WP_LIB_ADMIN_TABLES {
 		$this->wp_librarian = $wp_librarian;
 		
 		// Adds custom columns, removes unneeded columns and changes the order of columns
-		add_filter( 'manage_wp_lib_items_posts_columns',		array( $this,			'manageItemsTableColumns' ),	10, 1 );
-		add_filter( 'manage_wp_lib_members_posts_columns',		array( $this,			'manageMembersTableColumns' ),	10, 1 );
-		add_filter( 'manage_wp_lib_loans_posts_columns',		array( $this,			'manageLoansTableColumns' ),	10, 1 );
-		add_filter( 'manage_wp_lib_fines_posts_columns',		array( $this,			'manageFinesTableColumns' ),	10, 1 );
-		add_filter( 'manage_users_columns',						array( $this,			'manageUsersTableColumns' ),	10, 1 );
+		add_filter( 'manage_wp_lib_items_posts_columns',			array( $this,			'manageItemsTableColumns' ),		10, 1 );
+		add_filter( 'manage_wp_lib_members_posts_columns',			array( $this,			'manageMembersTableColumns' ),		10, 1 );
+		add_filter( 'manage_wp_lib_loans_posts_columns',			array( $this,			'manageLoansTableColumns' ),		10, 1 );
+		add_filter( 'manage_wp_lib_fines_posts_columns',			array( $this,			'manageFinesTableColumns' ),		10, 1 );
+		add_filter( 'manage_users_columns',							array( $this,			'manageUsersTableColumns' ),		10, 1 );
 		
-		add_action( 'load-edit.php',							array( $wp_librarian,	'loadObjectClasses' ) );
+		add_action( 'load-edit.php',								array( $wp_librarian,	'loadObjectClasses' ) );
 		
 		// Adds content to custom post table columns
-		add_action( 'manage_wp_lib_items_posts_custom_column',	array( $this,			'fillItemsTableColumns' ),		10, 2 );
-		add_action( 'manage_wp_lib_members_posts_custom_column',array( $this,			'fillMembersTableColumns' ),	10, 2 );
-		add_action( 'manage_wp_lib_loans_posts_custom_column',	array( $this,			'fillLoansTableColumns' ),		10, 2 );
-		add_action( 'manage_wp_lib_fines_posts_custom_column',	array( $this,			'fillFinesTableColumns' ),		10, 2 );
-		add_action( 'manage_users_custom_column',				array( $this,			'fillUsersTableColumns' ),		10, 3 );
+		add_action( 'manage_wp_lib_items_posts_custom_column',		array( $this,			'fillItemsTableColumns' ),			10, 2 );
+		add_action( 'manage_wp_lib_members_posts_custom_column',	array( $this,			'fillMembersTableColumns' ),		10, 2 );
+		add_action( 'manage_wp_lib_loans_posts_custom_column',		array( $this,			'fillLoansTableColumns' ),			10, 2 );
+		add_action( 'manage_wp_lib_fines_posts_custom_column',		array( $this,			'fillFinesTableColumns' ),			10, 2 );
+		add_action( 'manage_users_custom_column',					array( $this,			'fillUsersTableColumns' ),			10, 3 );
+		
+		// Makes relevant custom columns sortable
+		add_filter('manage_edit-wp_lib_items_sortable_columns',		array( $this,			'setSortableItemsTableColumns' ),	10, 1 );
+		add_filter('manage_edit-wp_lib_members_sortable_columns',	array( $this,			'setSortableMembersTableColumns' ),	10, 1 );
+		add_filter('manage_edit-wp_lib_loans_sortable_columns',		array( $this,			'setSortableLoansTableColumns' ),	10, 1 );
+		add_filter('manage_edit-wp_lib_fines_sortable_columns',		array( $this,			'setSortableFinesTableColumns' ),	10, 1 );
 		
 		// Removes bulk actions actions from loans and fines post tables
 		add_filter('bulk_actions-edit-wp_lib_loans',			function(){ return array(); });
@@ -342,6 +348,58 @@ class WP_LIB_ADMIN_TABLES {
 				return wp_lib_fetch_user_permission_status( $user_id );
 			break;
 		}
+	}
+	
+	/**
+	 * Allows items table to be sorted by appropriate custom columns
+	 * @param	Array	$columns	Array of sortable item table columns
+	 * @return	Array				Modified array of sortable table columns
+	 */
+	public function setSortableItemsTableColumns( Array $columns ) {
+		// Makes array of columns sortable
+			$columns[$sortable] = $columns;
+		}
+		
+		return $columns;
+	}
+	
+	/**
+	 * Allows members table to be sorted by appropriate custom columns
+	 * @param	Array	$columns	Array of sortable member table columns
+	 * @return	Array				Modified array of sortable table columns
+	 */
+	public function setSortableMembersTableColumns( Array $columns ) {
+		// Makes array of columns sortable
+			$columns[$sortable] = $columns;
+		}
+		
+		return $columns;
+	}
+	
+	/**
+	 * Allows loans table to be sorted by appropriate custom columns
+	 * @param	Array	$columns	Array of sortable loan table columns
+	 * @return	Array				Modified array of sortable table columns
+	 */
+	public function setSortableLoansTableColumns( Array $columns ) {
+		// Makes array of columns sortable
+			$columns[$sortable] = $columns;
+		}
+		
+		return $columns;
+	}
+	
+	/**
+	 * Allows fines table to be sorted by appropriate custom columns
+	 * @param	Array	$columns	Array of sortable fine table columns
+	 * @return	Array				Modified array of sortable table columns
+	 */
+	public function setSortableFinesTableColumns( Array $columns ) {
+		// Makes array of columns sortable
+			$columns[$sortable] = $columns;
+		}
+		
+		return $columns;
 	}
 }
 

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -23,49 +23,49 @@ class WP_LIB_ADMIN_TABLES {
 	/**
 	 * Adds WordPress hooks to add custom columns, remove unneeded default columns and add content to the custom columns
 	 */
-	function __construct( WP_LIBRARIAN $wp_librarian ) {
+	function __construct(WP_LIBRARIAN $wp_librarian) {
 		$this->wp_librarian = $wp_librarian;
 		
 		// Adds custom columns, removes unneeded columns and changes the order of columns
-		add_filter( 'manage_wp_lib_items_posts_columns',			array( $this,			'manageItemsTableColumns' ),		10, 1 );
-		add_filter( 'manage_wp_lib_members_posts_columns',			array( $this,			'manageMembersTableColumns' ),		10, 1 );
-		add_filter( 'manage_wp_lib_loans_posts_columns',			array( $this,			'manageLoansTableColumns' ),		10, 1 );
-		add_filter( 'manage_wp_lib_fines_posts_columns',			array( $this,			'manageFinesTableColumns' ),		10, 1 );
-		add_filter( 'manage_users_columns',							array( $this,			'manageUsersTableColumns' ),		10, 1 );
+		add_filter('manage_wp_lib_items_posts_columns',				array($this,			'manageItemsTableColumns'),			10, 1);
+		add_filter('manage_wp_lib_members_posts_columns',			array($this,			'manageMembersTableColumns'),		10, 1);
+		add_filter('manage_wp_lib_loans_posts_columns',				array($this,			'manageLoansTableColumns'),			10, 1);
+		add_filter('manage_wp_lib_fines_posts_columns',				array($this,			'manageFinesTableColumns'),			10, 1);
+		add_filter('manage_users_columns',							array($this,			'manageUsersTableColumns'),			10, 1);
 		
-		add_action( 'load-edit.php',								array( $wp_librarian,	'loadObjectClasses' ) );
+		add_action('load-edit.php',									array($wp_librarian,	'loadObjectClasses'));
 		
 		// Adds content to custom post table columns
-		add_action( 'manage_wp_lib_items_posts_custom_column',		array( $this,			'fillItemsTableColumns' ),			10, 2 );
-		add_action( 'manage_wp_lib_members_posts_custom_column',	array( $this,			'fillMembersTableColumns' ),		10, 2 );
-		add_action( 'manage_wp_lib_loans_posts_custom_column',		array( $this,			'fillLoansTableColumns' ),			10, 2 );
-		add_action( 'manage_wp_lib_fines_posts_custom_column',		array( $this,			'fillFinesTableColumns' ),			10, 2 );
-		add_action( 'manage_users_custom_column',					array( $this,			'fillUsersTableColumns' ),			10, 3 );
+		add_action('manage_wp_lib_items_posts_custom_column',		array($this,			'fillItemsTableColumns'),			10, 2);
+		add_action('manage_wp_lib_members_posts_custom_column',		array($this,			'fillMembersTableColumns'),			10, 2);
+		add_action('manage_wp_lib_loans_posts_custom_column',		array($this,			'fillLoansTableColumns'),			10, 2);
+		add_action('manage_wp_lib_fines_posts_custom_column',		array($this,			'fillFinesTableColumns'),			10, 2);
+		add_action('manage_users_custom_column',					array($this,			'fillUsersTableColumns'),			10, 3);
 		
 		// Makes relevant custom columns sortable
-		add_filter( 'manage_edit-wp_lib_items_sortable_columns',	array( $this,			'setSortableItemsTableColumns' ),	10, 1 );
-		add_filter( 'manage_edit-wp_lib_members_sortable_columns',	array( $this,			'setSortableMembersTableColumns' ),	10, 1 );
-		add_filter( 'manage_edit-wp_lib_loans_sortable_columns',	array( $this,			'setSortableLoansTableColumns' ),	10, 1 );
-		add_filter( 'manage_edit-wp_lib_fines_sortable_columns',	array( $this,			'setSortableFinesTableColumns' ),	10, 1 );
+		add_filter('manage_edit-wp_lib_items_sortable_columns',		array($this,			'setSortableItemsTableColumns'),	10, 1);
+		add_filter('manage_edit-wp_lib_members_sortable_columns',	array($this,			'setSortableMembersTableColumns'),	10, 1);
+		add_filter('manage_edit-wp_lib_loans_sortable_columns',		array($this,			'setSortableLoansTableColumns'),	10, 1);
+		add_filter('manage_edit-wp_lib_fines_sortable_columns',		array($this,			'setSortableFinesTableColumns'),	10, 1);
 		
 		// Adds custom sorting logic to custom taxonomy columns
-		add_filter( 'posts_clauses',								array($this,			'sortCustomTaxColumns'),			10, 2);
+		add_filter('posts_clauses',									array($this,			'sortCustomTaxColumns'),			10, 2);
 		
 		// Adds custom sorting logic to columns that rely on meta-based foreign keys
-		add_filter( 'posts_clauses',								array($this,			'sortCustomForeignMetaColumns'),	10, 2);
+		add_filter('posts_clauses',									array($this,			'sortCustomForeignMetaColumns'),	10, 2);
 		
 		// Adds logic to sort the members table by the 'Items Donated' column
-		add_filter(	'posts_clauses',								array($this,			'sortCustomItemsDonatedColumn'),	10, 2);
+		add_filter('posts_clauses',									array($this,			'sortCustomItemsDonatedColumn'),	10, 2);
 		
 		// Adds logic to sort the members table by the 'Items on Loan' column
-		add_filter( 'posts_clauses',								array($this,			'sortCustomItemsOnLoanColumn'),		10, 2);
+		add_filter('posts_clauses',									array($this,			'sortCustomItemsOnLoanColumn'),		10, 2);
 		
 		// Adds custom sorting logic to custom post meta columns
-		add_action( 'pre_get_posts',								array($this,			'sortCustomMetaColumns'),			10, 1);
+		add_action('pre_get_posts',									array($this,			'sortCustomMetaColumns'),			10, 1);
 		
 		// Removes bulk actions actions from loans and fines post tables
-		add_filter( 'bulk_actions-edit-wp_lib_loans',				function(){ return array(); });
-		add_filter( 'bulk_actions-edit-wp_lib_fines',				function(){ return array(); });
+		add_filter('bulk_actions-edit-wp_lib_loans',				function(){ return array(); });
+		add_filter('bulk_actions-edit-wp_lib_fines',				function(){ return array(); });
 	}
 	
 	/**
@@ -73,13 +73,13 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	int		$item_id		Post ID to get post meta from
 	 * @param	string	$meta_key		Post meta key where timestamp is located
 	 */
-	private function dateColumn( $post_id, $meta_key ) {
+	private function dateColumn($post_id, $meta_key) {
 		// Fetches date from post meta using given key
-		$date = get_post_meta( $post_id, $meta_key, true );
+		$date = get_post_meta($post_id, $meta_key, true);
 		
 		// If date is valid returns formatted date
-		if ( is_numeric( $date ) )
-			echo wp_lib_format_unix_timestamp( $date );
+		if (is_numeric($date))
+			echo wp_lib_format_unix_timestamp($date);
 		// Otherwise return dash to indicate missing/unknown information
 		else
 			echo '-';
@@ -91,7 +91,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	array				Modified WordPress post table columns
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 */
-	public function manageItemsTableColumns( $columns ) {	
+	public function manageItemsTableColumns($columns) {	
 		// Adds item status and item condition columns
 		$new_columns = array(
 			'item_status'		=> 'Loan Status',
@@ -99,7 +99,7 @@ class WP_LIB_ADMIN_TABLES {
 		);
 		
 		// Adds new columns between existing ones
-		$columns = array_slice( $columns, 0, 4, true ) + $new_columns + array_slice( $columns, 4, NULL, true );
+		$columns = array_slice($columns, 0, 4, true) + $new_columns + array_slice($columns, 4, NULL, true);
 		
 		return $columns;
 	}
@@ -110,7 +110,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	array				Modified WordPress post table columns
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 */
-	public function manageMembersTableColumns( $columns ) {
+	public function manageMembersTableColumns($columns) {
 		// Initialises new columns
 		$new_columns = array(
 			'member_name'		=> 'Name',
@@ -120,7 +120,7 @@ class WP_LIB_ADMIN_TABLES {
 		);
 		
 		// Adds new columns between existing ones
-		return array_slice( $columns, 0, 1, true ) + $new_columns;
+		return array_slice($columns, 0, 1, true) + $new_columns;
 	}
 	
 	/**
@@ -130,7 +130,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 * @todo						Test function without accepting $columns as an argument and setting the filter params to 0
 	 */
-	public function manageLoansTableColumns( $columns ) {
+	public function manageLoansTableColumns($columns) {
 		return array(
 			'loan_loan'			=> 'Loan',
 			'loan_item'			=> 'Item',
@@ -149,7 +149,7 @@ class WP_LIB_ADMIN_TABLES {
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
 	 * @todo						Test function without accepting $columns as an argument and setting the filter params to 0
 	 */
-	public function manageFinesTableColumns( $columns ) {
+	public function manageFinesTableColumns($columns) {
 		return array(
 			'fine_fine'			=> 'Fine',
 			'fine_item'			=> 'Item',
@@ -165,8 +165,8 @@ class WP_LIB_ADMIN_TABLES {
 	 * @return	array				Modified WordPress user table columns
 	 * @see							http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_users_columns
 	 */
-	public function manageUsersTableColumns( $columns ) {
-		return array_slice( $columns, 0, 5, true ) + array('library-role' => 'Library Role') + array_slice( $columns, 5, NULL, true );
+	public function manageUsersTableColumns($columns) {
+		return array_slice($columns, 0, 5, true) + array('library-role' => 'Library Role') + array_slice($columns, 5, NULL, true);
 	}
 	
 	/**
@@ -175,23 +175,23 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	int		$item_id	Post ID of current row's item
 	 * @see							http://codex.wordpress.org/Plugin_API/Action_Reference/manage_posts_custom_column
 	 */
-	public function fillItemsTableColumns( $column, $item_id ) {
-		if ( $this->row_buffer[0] !== $item_id ) {
+	public function fillItemsTableColumns($column, $item_id) {
+		if ($this->row_buffer[0] !== $item_id) {
 			$this->row_buffer = array(
 				$item_id,
-				WP_LIB_ITEM::create( $this->wp_librarian, $item_id )
+				WP_LIB_ITEM::create($this->wp_librarian, $item_id)
 			);
 		}
 		
-		switch ( $column ) {
+		switch ($column) {
 			// Displays the current status of the item (On Loan/Available/Late)
 			case 'item_status':
-				echo $this->row_buffer[1]->formattedStatus( false, true );
+				echo $this->row_buffer[1]->formattedStatus(false, true);
 			break;
 			
 			// Fetches and formats the condition the item is in, using a placeholder if the condition is unspecified
 			case 'item_condition':
-				echo wp_lib_format_item_condition( get_post_meta( $item_id, 'wp_lib_item_condition', true ) );
+				echo wp_lib_format_item_condition(get_post_meta($item_id, 'wp_lib_item_condition', true));
 			break;
 		}
 	}
@@ -202,28 +202,28 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	int		$member_id	Post ID of current row's member
 	 * @see							http://codex.wordpress.org/Plugin_API/Action_Reference/manage_posts_custom_column
 	 */
-	public function fillMembersTableColumns( $column, $member_id ) {
-		if ( $this->row_buffer[0] !== $member_id ) {
+	public function fillMembersTableColumns($column, $member_id) {
+		if ($this->row_buffer[0] !== $member_id) {
 			$this->row_buffer = array(
 				$member_id,
-				WP_LIB_MEMBER::create( $this->wp_librarian, $member_id )
+				WP_LIB_MEMBER::create($this->wp_librarian, $member_id)
 			);
 		}
 		
-		switch ( $column ) {
+		switch ($column) {
 			// Displays the current status of the item (On Loan/Available/Late)
 			case 'member_name':
-				echo wp_lib_manage_member_hyperlink( $member_id );
+				echo wp_lib_manage_member_hyperlink($member_id);
 			break;
 			
 			// Displays number of items currently in the possession of the member
 			case 'member_loans':
-				echo wp_lib_prep_members_items_out( $member_id );
+				echo wp_lib_prep_members_items_out($member_id);
 			break;
 			
 			// Displays total amount currently owed to the Library in late item fines
 			case 'member_fines':
-				echo wp_lib_format_money( (float) $this->row_buffer[1]->getMoneyOwed() );
+				echo wp_lib_format_money((float) $this->row_buffer[1]->getMoneyOwed());
 			break;
 			
 			// Displays total number of items donated by the member to the Library
@@ -248,43 +248,43 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	int		$loan_id	Post ID of current row's loan
 	 * @see							http://codex.wordpress.org/Plugin_API/Action_Reference/manage_posts_custom_column
 	 */
-	public function fillLoansTableColumns( $column, $loan_id ) {
-		switch ( $column ) {
+	public function fillLoansTableColumns($column, $loan_id) {
+		switch ($column) {
 			// Displays link to manage loan
 			case 'loan_loan':
-				echo wp_lib_hyperlink( wp_lib_manage_loan_url( $loan_id ), '#' . $loan_id );
+				echo wp_lib_hyperlink(wp_lib_manage_loan_url($loan_id), '#' . $loan_id);
 			break;
 			
 			// Displays title of loaned item with link to view item
 			case 'loan_item':
 				// Fetches item ID from loan meta
-				$item_id = get_post_meta( $loan_id, 'wp_lib_item', true );
+				$item_id = get_post_meta($loan_id, 'wp_lib_item', true);
 				
 				// Renders item title formatted as hyperlink to manage item
-				echo wp_lib_manage_item_hyperlink( $item_id );
+				echo wp_lib_manage_item_hyperlink($item_id);
 			break;
 			
 			// Displays member that item has been loaned to
 			case 'loan_member':
 				// Renders member's name as a link to manage that member
-				echo wp_lib_manage_member_hyperlink( get_post_meta( $loan_id, 'wp_lib_member', true ) );
+				echo wp_lib_manage_member_hyperlink(get_post_meta($loan_id, 'wp_lib_member', true));
 			break;
 			
 			// Displays loan status (Open/Closed)
 			case 'loan_status':
 				// Fetches status from loan meta
-				$status = get_post_meta( $loan_id, 'wp_lib_status', true );
+				$status = get_post_meta($loan_id, 'wp_lib_status', true);
 				
 				// Formats status
-				$status_formatted = wp_lib_format_loan_status( $status );
+				$status_formatted = wp_lib_format_loan_status($status);
 				
 				// If loan status indicates a fine was charged
-				if ( $status == 4 ){
+				if ($status == 4){
 					// Fetches fine ID from loan meta
-					$fine_id = get_post_meta( $loan_id, 'wp_lib_fine', true );
+					$fine_id = get_post_meta($loan_id, 'wp_lib_fine', true);
 					
 					// Creates and displays hyperlink
-					echo wp_lib_hyperlink( wp_lib_manage_fine_url( $fine_id ), $status_formatted );
+					echo wp_lib_hyperlink(wp_lib_manage_fine_url($fine_id), $status_formatted);
 				}
 				else {
 					// Otherwise displays status (no hyperlink)
@@ -294,17 +294,17 @@ class WP_LIB_ADMIN_TABLES {
 			
 			// Displays date item was loaned
 			case 'loan_start':
-				$this->dateColumn( $loan_id, 'wp_lib_start_date' );
+				$this->dateColumn($loan_id, 'wp_lib_start_date');
 			break;
 			
 			// Displays date item should be returned by
 			case 'loan_end':
-				$this->dateColumn( $loan_id, 'wp_lib_end_date' );
+				$this->dateColumn($loan_id, 'wp_lib_end_date');
 			break;
 			
 			// Displays date item was actually returned
 			case 'loan_returned':
-				$this->dateColumn( $loan_id, 'wp_lib_return_date' );
+				$this->dateColumn($loan_id, 'wp_lib_return_date');
 			break;
 		}
 	}
@@ -315,39 +315,39 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	int		$fine_id	Post ID of current row's fines
 	 * @see							http://codex.wordpress.org/Plugin_API/Action_Reference/manage_posts_custom_column
 	 */
-	public function fillFinesTableColumns( $column, $fine_id ) {
-		switch ( $column ) {
+	public function fillFinesTableColumns($column, $fine_id) {
+		switch ($column) {
 			// Displays link to manage fine
 			case 'fine_fine':
-				echo wp_lib_hyperlink( wp_lib_manage_fine_url( $fine_id ), '#' . $fine_id );
+				echo wp_lib_hyperlink(wp_lib_manage_fine_url($fine_id), '#' . $fine_id);
 			break;
 			
 			// Displays item that caused fine creation with link to manage item
 			case 'fine_item':
-				echo wp_lib_manage_item_hyperlink( get_post_meta( $fine_id, 'wp_lib_item', true ) );
+				echo wp_lib_manage_item_hyperlink(get_post_meta($fine_id, 'wp_lib_item', true));
 			break;
 			
 			// Displays member that has been fined as link to manage member
 			case 'fine_member':
-				echo wp_lib_manage_member_hyperlink( get_post_meta( $fine_id, 'wp_lib_member', true ) );
+				echo wp_lib_manage_member_hyperlink(get_post_meta($fine_id, 'wp_lib_member', true));
 			break;
 			
 			// Displays status of fine (whether it is unpaid/paid/cancelled)
 			case 'fine_status':
 				// Fetches fine status then formats as readable string e.g. 1 => 'Unpaid'
-				$status = wp_lib_format_fine_status( get_post_meta( $fine_id, 'wp_lib_status', true ) );
+				$status = wp_lib_format_fine_status(get_post_meta($fine_id, 'wp_lib_status', true));
 				
 				// Renders fine status 
-				echo wp_lib_hyperlink( wp_lib_manage_fine_url( $fine_id ), $status );
+				echo wp_lib_hyperlink(wp_lib_manage_fine_url($fine_id), $status);
 			break;
 			
 			// Displays total charge to member
 			case 'fine_amount':
 				// Fetches fine amount from fine's post meta
-				$fine = get_post_meta( $fine_id, 'wp_lib_owed', true );
+				$fine = get_post_meta($fine_id, 'wp_lib_owed', true);
 				
 				// Formats fine with local currency and displays it
-				echo wp_lib_format_money( $fine );
+				echo wp_lib_format_money($fine);
 			break;
 		}
 	}
@@ -357,10 +357,10 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	string	$column		Name of an fines post table column
 	 * @param	int		$fine_id	Post ID of current row's fines
 	 */
-	public function fillUsersTableColumns( $value='', $column, $user_id ) {
-		switch( $column ) {
+	public function fillUsersTableColumns($value='', $column, $user_id) {
+		switch($column) {
 			case 'library-role':
-				return wp_lib_fetch_user_permission_status( $user_id );
+				return wp_lib_fetch_user_permission_status($user_id);
 			break;
 		}
 	}
@@ -370,9 +370,9 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	Array	$columns	Array of sortable item table columns
 	 * @return	Array				Modified array of sortable table columns
 	 */
-	public function setSortableItemsTableColumns( Array $columns ) {
+	public function setSortableItemsTableColumns(Array $columns) {
 		// Makes array of columns sortable
-		foreach(['taxonomy-wp_lib_media_type','taxonomy-wp_lib_author','item_status','item_condition'] as $sortable ) {
+		foreach(['taxonomy-wp_lib_media_type','taxonomy-wp_lib_author','item_status','item_condition'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
 		
@@ -384,9 +384,9 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	Array	$columns	Array of sortable member table columns
 	 * @return	Array				Modified array of sortable table columns
 	 */
-	public function setSortableMembersTableColumns( Array $columns ) {
+	public function setSortableMembersTableColumns(Array $columns) {
 		// Makes array of columns sortable
-		foreach(['member_name','member_loans','member_fines','member_donated'] as $sortable ) {
+		foreach(['member_name','member_loans','member_fines','member_donated'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
 		
@@ -398,9 +398,9 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	Array	$columns	Array of sortable loan table columns
 	 * @return	Array				Modified array of sortable table columns
 	 */
-	public function setSortableLoansTableColumns( Array $columns ) {
+	public function setSortableLoansTableColumns(Array $columns) {
 		// Makes array of columns sortable
-		foreach(['loan_loan','loan_item','loan_member','loan_status','loan_start','loan_end','loan_returned'] as $sortable ) {
+		foreach(['loan_loan','loan_item','loan_member','loan_status','loan_start','loan_end','loan_returned'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
 		
@@ -412,9 +412,9 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	Array	$columns	Array of sortable fine table columns
 	 * @return	Array				Modified array of sortable table columns
 	 */
-	public function setSortableFinesTableColumns( Array $columns ) {
+	public function setSortableFinesTableColumns(Array $columns) {
 		// Makes array of columns sortable
-		foreach(['fine_fine','fine_item','fine_member','fine_status','fine_amount'] as $sortable ) {
+		foreach(['fine_fine','fine_item','fine_member','fine_status','fine_amount'] as $sortable) {
 			$columns[$sortable] = $sortable;
 		}
 		
@@ -429,11 +429,11 @@ class WP_LIB_ADMIN_TABLES {
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomTaxColumns( Array $clauses, WP_Query $wp_query ) {
-		if ( !isset($wp_query->query['orderby']) )
+	public function sortCustomTaxColumns(Array $clauses, WP_Query $wp_query) {
+		if (!isset($wp_query->query['orderby']))
 			return $clauses;
 		
-		switch( $wp_query->query['orderby'] ) {
+		switch($wp_query->query['orderby']) {
 			case 'taxonomy-wp_lib_author':
 				$taxonomy = 'wp_lib_author';
 			break;
@@ -455,10 +455,10 @@ LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
 LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
 SQL;
 		
-		$clauses['where'] .= " AND (taxonomy = '".$taxonomy."' OR taxonomy IS NULL)";
-		$clauses['groupby'] = "object_id";
-		$clauses['orderby']  = "GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC) ";
-		$clauses['orderby'] .= ( 'ASC' === strtoupper( $wp_query->get('order') ) ) ? 'ASC' : 'DESC';
+		$clauses['where']	.=	" AND (taxonomy = '".$taxonomy."' OR taxonomy IS NULL)";
+		$clauses['groupby']	=	"object_id";
+		$clauses['orderby']	=	"GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC) ";
+		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
 
 		return $clauses;
 	}
@@ -470,11 +470,11 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomForeignMetaColumns( Array $clauses, WP_Query $wp_query ) {
+	public function sortCustomForeignMetaColumns(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']))
 			return $clauses;
 		
-		switch( $wp_query->query['orderby'] ) {
+		switch($wp_query->query['orderby']) {
 			// The item title column of the loans table
 			case 'loan_item':
 				$meta_key	= 'wp_lib_item';
@@ -508,8 +508,8 @@ LEFT OUTER JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID={$wpdb->postmeta}.post_id
 LEFT OUTER JOIN {$wpdb->posts} AS wp_lib_cpt ON meta_value=wp_lib_cpt.ID
 SQL;
 		
-		$clauses['orderby'] = "wp_lib_cpt.post_title ";
-		$clauses['orderby'] .= ( 'ASC' === strtoupper( $wp_query->get('order') ) ) ? 'ASC' : 'DESC';
+		$clauses['orderby']	=	"wp_lib_cpt.post_title ";
+		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
 		
 		return $clauses;
 	}
@@ -520,16 +520,16 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomItemsDonatedColumn( Array $clauses, WP_Query $wp_query ) {
+	public function sortCustomItemsDonatedColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']) || $wp_query->query['orderby'] !== 'member_donated')
 			return $clauses;
 		
 		global $wpdb;
 		
-		$clauses['join'] .= "LEFT OUTER JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID={$wpdb->postmeta}.meta_value AND {$wpdb->postmeta}.meta_key='wp_lib_item_donor'";
-		$clauses['groupby'] = "ID";
-		$clauses['orderby'] = "COUNT(meta_value) ";
-		$clauses['orderby'] .= ( 'ASC' === strtoupper( $wp_query->get('order') ) ) ? 'ASC' : 'DESC';
+		$clauses['join']	.=	"LEFT OUTER JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID={$wpdb->postmeta}.meta_value AND {$wpdb->postmeta}.meta_key='wp_lib_item_donor'";
+		$clauses['groupby']	=	"ID";
+		$clauses['orderby']	=	"COUNT(meta_value) ";
+		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
 		
 		return $clauses;
 	}
@@ -542,7 +542,7 @@ SQL;
 	 * @param	WP_Query	$wp_query	A request to WordPress for posts
 	 * @return	Array					Modified SQL clauses
 	 */
-	public function sortCustomItemsOnLoanColumn( Array $clauses, WP_Query $wp_query ) {
+	public function sortCustomItemsOnLoanColumn(Array $clauses, WP_Query $wp_query) {
 		if (!isset($wp_query->query['orderby']) || $wp_query->query['orderby'] !== 'member_loans')
 			return $clauses;
 		
@@ -565,9 +565,9 @@ OR {$wpdb->posts}.post_status = 'private')
 ON {$wpdb->posts}.ID = loans.member_id
 SQL;
 		
-		$clauses['groupby'] = "{$wpdb->posts}.ID";
-		$clauses['orderby']  = "COUNT(loans.member_id) ";
-		$clauses['orderby'] .= ( 'ASC' === strtoupper( $wp_query->get('order') ) ) ? 'ASC' : 'DESC';
+		$clauses['groupby']	=	"{$wpdb->posts}.ID";
+		$clauses['orderby'] =	"COUNT(loans.member_id) ";
+		$clauses['orderby']	.=	('ASC' === strtoupper($wp_query->get('order'))) ? 'ASC' : 'DESC';
 		
 		return $clauses;
 	}
@@ -576,12 +576,12 @@ SQL;
 	 * Tells WordPress how to sort the Items table's custom post meta columns
 	 * @param	Array		$vars		Query variables passed to default main SQL query
 	 */
-	public function sortCustomMetaColumns( WP_Query $query ) {
-		if( !is_admin() )  
+	public function sortCustomMetaColumns(WP_Query $query) {
+		if(!is_admin())  
 			return;
 		
 		// Adds sorting logic based on column being sorted
-		switch( $query->get( 'orderby') ) {
+		switch($query->get( 'orderby')) {
 			case 'item_status':
 				// Requires special logic
 			break;

--- a/lib/admin-tables.class.php
+++ b/lib/admin-tables.class.php
@@ -357,6 +357,7 @@ class WP_LIB_ADMIN_TABLES {
 	 */
 	public function setSortableItemsTableColumns( Array $columns ) {
 		// Makes array of columns sortable
+		foreach(['taxonomy-wp_lib_media_type','taxonomy-wp_lib_author','item_status','item_condition'] as $sortable ) {
 			$columns[$sortable] = $columns;
 		}
 		
@@ -370,6 +371,7 @@ class WP_LIB_ADMIN_TABLES {
 	 */
 	public function setSortableMembersTableColumns( Array $columns ) {
 		// Makes array of columns sortable
+		foreach(['member_name','member_loans','member_fines','member_donated'] as $sortable ) {
 			$columns[$sortable] = $columns;
 		}
 		
@@ -383,6 +385,7 @@ class WP_LIB_ADMIN_TABLES {
 	 */
 	public function setSortableLoansTableColumns( Array $columns ) {
 		// Makes array of columns sortable
+		foreach(['loan_loan','loan_item','loan_member','loan_status','loan_start','loan_end','loan_returned'] as $sortable ) {
 			$columns[$sortable] = $columns;
 		}
 		
@@ -396,6 +399,7 @@ class WP_LIB_ADMIN_TABLES {
 	 */
 	public function setSortableFinesTableColumns( Array $columns ) {
 		// Makes array of columns sortable
+		foreach(['fine_fine','fine_item','fine_member','fine_status','fine_amount'] as $sortable ) {
 			$columns[$sortable] = $columns;
 		}
 		


### PR DESCRIPTION
All tables that could be sorted by custom columns now have custom logic to do so. The exception being the member owed column, which is noted in 79ed43c86b1eb4518f5681b1ec12f9c9635079e1.

Merging this branch concerns #35 and its connected issue #40 and #41.